### PR TITLE
fixes for closure compiler

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -67,7 +67,8 @@ printStackTrace.implementation.prototype = {
         ex = ex ||
             (function() {
                 try {
-                    var _err = undef.voidprop
+                    this.undef();
+					return null;
                 } catch (e) {
                     return e;
                 }


### PR DESCRIPTION
Almost all code works with closure compiler's SIMPLE_OPTIMIZATIONS setting, but there were two issues in this package that were easy to work around that are now fixed.
