### PR TITLE
Fixing null exception when tracing a function with no arguments

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -199,7 +199,7 @@ printStackTrace.implementation.prototype = {
         
         while (curr && stack.length < maxStackSize) {
             fn = fnRE.test(curr.toString()) ? RegExp.$1 || ANON : ANON;
-            args = Array.prototype.slice.call(curr['arguments']);
+            args = Array.prototype.slice.call(curr['arguments'] || []);
             stack[stack.length] = fn + '(' + this.stringifyArguments(args) + ')';
             curr = curr.caller;
         }


### PR DESCRIPTION
I encountered a null reference exception on IE9 when stacktrace tried to dump the trace of a function with no arguments. This was easily fixed by defaulting to an empty array if the arguments array was null on line 202:

args = Array.prototype.slice.call(curr['arguments'] || []);
