### PR TITLE
Stacktrace support in Chromium

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -215,7 +215,6 @@ printStackTrace.implementation.prototype = {
             return;
         }
         req.open('GET', url, false);
-        req.setRequestHeader('User-Agent', 'XMLHTTP/1.0');
         req.send('');
         return req.responseText;
     },


### PR DESCRIPTION
There was two issues:
1. 56c407e2 Stacktrace items like "http://example.com/foo.js:51/3" wasn't parsed preperly. I've splitted regular expressions to parse URL and lineno/charno separately.  
2. ae6843a5 Chromium doesn't support setting User-Agent in request. It print "Refused to set unsafe header "User-Agent"" warning instead. This feature seem useless, so I just removed this code. 
