### PR TITLE
Stacktrace crash on eval of anonymous function

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -346,11 +346,13 @@ printStackTrace.implementation.prototype = {
                 frame = stack[i], ref = reStack.exec(frame);
 
             if (ref) {
-                var m = reRef.exec(ref[1]), file = m[1],
-                    lineno = m[2], charno = m[3] || 0;
-                if (file && this.isSameDomain(file) && lineno) {
-                    var functionName = this.guessAnonymousFunction(file, lineno, charno);
-                    stack[i] = frame.replace('{anonymous}', functionName);
+                var m = reRef.exec(ref[1]);
+                if (m){
+                    var file = m[1], lineno = m[2], charno = m[3] || 0;
+                    if (file && this.isSameDomain(file) && lineno) {
+                        var functionName = this.guessAnonymousFunction(file, lineno, charno);
+                        stack[i] = frame.replace('{anonymous}', functionName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'm seeing an exception when trying to create a stacktrace for tracing purposes.

The actual window level error is reported as this:

```
Uncaught TypeError: Cannot read property '1' of null
URL: http://localhost:4000/javascripts/stacktrace.js
Line: 349
```

So the call "m[1]" is failing in stacktrace.js

Here is the output for the "ref" object at that time

```
Array[2]
0: "{anonymous}()@eval at buildTmplFn (http://localhost:4000/javascripts/jquery/jquery.tmpl.js:317:10)"
1: "eval at buildTmplFn (http://localhost:4000/javascripts/jquery/jquery.tmpl.js:317:10)"
index: 0
input: "{anonymous}()@eval at buildTmplFn (http://localhost:4000/javascripts/jquery/jquery.tmpl.js:317:10)"
length: 2
__proto__: Array[0]
```

The jquery file used is this one, http://cloud.github.com/downloads/SteveSanderson/knockout/jquery.tmpl.js

It's quite a dense function to look into, but suffice to say stacktrace.js fails to evaluate "m" at line 349 of stacktrace.js as anything other than null. This causes the stacktrace construction to blow out.

This simple pull request change evades the issue. It happens rarely (but reliably) under certain uses of jquery templating.

Not the best pull request summary I've ever done, sorry, but I assure you the problem and solution are genuine.

Let me know if there is any more logging you need.

H
