### PR TITLE
When running under nodejs location is undefined, correct isSameDomain to not throw exception.

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -325,9 +325,7 @@ printStackTrace.implementation.prototype = {
      * @return False if we need a cross-domain request
      */
     isSameDomain: function(url) {
-        if (typeof(location) === "undefined")
-            return false;
-        return url.indexOf(location.hostname) !== -1;
+        return typeof location !== "undefined" && url.indexOf(location.hostname) !== -1; // location may not be defined, e.g. when running from nodejs.
     },
 
     /**


### PR DESCRIPTION
Including stacktrace.js into code running on a nodejs server will result in exceptions being thrown when the 'location' global is accessed, it is not defined when running on nodejs.

This fix does a simple detect for that and returns false from isSameDomain.
