### PR TITLE
Ignore directory 'test' in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "dependencies": {},
   "ignore": [
     "**/.*",
+    "test"
     "node_modules",
     "components"
   ]


### PR DESCRIPTION
When adding stacktrace.js as dependency through bower, you'll receive a 6.5 MB package.
Including 4 MB jsTestDriver.jar.

Could you add the 'test' directory to the 'ignore' section in bower.json?
