### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
     "name": "stacktrace-js",
-    "version": "0.6.4",
     "main": "./stacktrace.js",
     "homepage": "https://github.com/stacktracejs/stacktrace.js",
     "authors": [


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property