### PR TITLE
remove explicit construction

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -80,21 +80,15 @@
         fromError: function StackTrace$$fromError(error, opts) {
             opts = _merge(_options, opts);
             var gps = new StackTraceGPS(opts);
-            return new Promise(function(resolve) {
-                var stackframes = ErrorStackParser.parse(error);
-                if (typeof opts.filter === 'function') {
-                    stackframes = stackframes.filter(opts.filter);
-                }
-                resolve(Promise.all(stackframes.map(function(sf) {
-                    return new Promise(function(resolve) {
-                        function resolveOriginal() {
-                            resolve(sf);
-                        }
-
-                        gps.pinpoint(sf).then(resolve, resolveOriginal)['catch'](resolveOriginal);
-                    });
-                })));
-            }.bind(this));
+            var stackframes = ErrorStackParser.parse(error);
+            if (typeof opts.filter === 'function') {
+                stackframes = stackframes.filter(opts.filter);
+            }
+            return Promise.all(stackframes.map(function(sf) {
+                return gps.pinpoint(sf);
+            }).catch(function(error) {
+                return sf;
+            }));
         },
 
         /**


### PR DESCRIPTION
## Description

Removes explicit construction for promise code.
## Motivation and Context

It's cleaner design.

## How Has This Been Tested?

I did not test this at all but I've literally refactored code this way a thousand times.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc stacktrace.js` passes without errors
- [ ] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

The promise usage left some to be desired and I felt like I should help by refactoring out [explicit construction](http://stackoverflow.com/questions/23803743/what-is-the-explicit-promise-construction-antipattern-and-how-do-i-avoid-it/23803744#23803744) which I used to do myself when I started with promises.

Thanks for the library.