### PR TITLE
fix old IE issue I created in #166

### DIFF
--- a/stacktrace.js
+++ b/stacktrace.js
@@ -86,7 +86,7 @@
             }
             return Promise.all(stackframes.map(function(sf) {
                 return gps.pinpoint(sf);
-            }).catch(function(error) {
+            })["catch"](function(error) {
                 return sf;
             }));
         },


### PR DESCRIPTION

I caused a compatibility issue in https://github.com/stacktracejs/stacktrace.js/pull/166 
since reserved keywords can't be property names in ES3.

This fixes it.