### PR TITLE
Enable TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,10 @@
     "CHANGELOG.md",
     "README.md",
     "stacktrace.js",
+    "stacktrace-js.d.ts",
     "dist/"
   ],
+  "typings": "./stacktrace-js.d.ts",
   "scripts": {
     "test": "gulp test",
     "prepublish": "gulp dist"


### PR DESCRIPTION
## Description
Thanks for your project!
I noticed that `stacktrace.js` has typings for TypeScript but unfortunately doesn't enable it (https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package).

## Motivation and Context
https://github.com/stacktracejs/stacktrace.js/issues/204

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] `node_modules/.bin/jscs -c .jscsrc stacktrace.js` passes without errors
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
