### PR TITLE
Upgrade natives from 1.1.4 to 1.1.6 to fix ‘npm install’ on Node ≥ 10.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -677,7 +677,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -7112,9 +7113,9 @@
       }
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "natural-compare": {
@@ -8832,7 +8833,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }


### PR DESCRIPTION
## Description

Without this, `npm install` fails on Node ≥ 10.15.0 (to say nothing of 12.x or 14.x, which Gulp 3 doesn’t support at all):

```
$ npm install

> stacktrace-js@2.0.2 prepare /home/anders/js/stacktrace.js
> gulp dist

internal/util/inspect.js:31
const types = internalBinding('types');
              ^

ReferenceError: internalBinding is not defined
    at internal/util/inspect.js:31:15
    at req_ (/home/anders/js/stacktrace.js/node_modules/natives/index.js:137:5)
    at require (/home/anders/js/stacktrace.js/node_modules/natives/index.js:110:12)
    at util.js:25:21
    at req_ (/home/anders/js/stacktrace.js/node_modules/natives/index.js:137:5)
    at require (/home/anders/js/stacktrace.js/node_modules/natives/index.js:110:12)
    at fs.js:42:21
    at req_ (/home/anders/js/stacktrace.js/node_modules/natives/index.js:137:5)
    at Object.req [as require] (/home/anders/js/stacktrace.js/node_modules/natives/index.js:54:10)
    at Object.<anonymous> (/home/anders/js/stacktrace.js/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:37)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! stacktrace-js@2.0.2 prepare: `gulp dist`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the stacktrace-js@2.0.2 prepare script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/anders/.npm/_logs/2021-03-25T00_14_18_635Z-debug.log
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc stacktrace.js` passes without errors
  - You don’t use JSCS anymore.
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
