### PR TITLE
gulpfile: Remove reference to missing test task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,5 +50,5 @@ gulp.task('dist', function() {
 gulp.task('clean', del.bind(null, ['build', 'dist']));
 
 gulp.task('default', ['clean'], function(cb) {
-    runSequence('dist', 'test', cb);
+    runSequence('dist', cb);
 });


### PR DESCRIPTION
## Description

The task was removed in 4d60cccd5ec10ac9f68c87025d17f89a4efbbfd8, causing this error:

```
$ npx gulp
[17:21:24] Using gulpfile ~/js/stacktrace.js/gulpfile.js
[17:21:24] Starting 'clean'...
[17:21:24] Finished 'clean' after 4.59 ms
[17:21:24] Starting 'default'...
[17:21:24] 'default' errored after 436 μs
[17:21:24] Error: Task test is not configured as a task on gulp.  If this is a submodule, you may need to use require('run-sequence').use(gulp).
    at /home/anders/js/stacktrace.js/node_modules/run-sequence/index.js:20:10
    at Array.forEach (<anonymous>)
    at verifyTaskSets (/home/anders/js/stacktrace.js/node_modules/run-sequence/index.js:13:11)
    at runSequence (/home/anders/js/stacktrace.js/node_modules/run-sequence/index.js:92:2)
    at Gulp.<anonymous> (/home/anders/js/stacktrace.js/gulpfile.js:53:5)
    at module.exports (/home/anders/js/stacktrace.js/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/home/anders/js/stacktrace.js/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/home/anders/js/stacktrace.js/node_modules/orchestrator/index.js:214:10)
    at /home/anders/js/stacktrace.js/node_modules/orchestrator/index.js:279:18
    at finish (/home/anders/js/stacktrace.js/node_modules/orchestrator/lib/runTask.js:21:8)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc stacktrace.js` passes without errors
  - You don’t use JSCS anymore.
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
