### PR TITLE
Import the TypeScript definition for StackFrame from stackframe

### DIFF
--- a/stacktrace-js.d.ts
+++ b/stacktrace-js.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Eric Wendelin <https://github.com/exceptionless>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import StackFrame = require("stackframe");
+
 declare namespace StackTrace {
 
     export interface SourceCache {
@@ -13,56 +15,6 @@ declare namespace StackTrace {
         filter?: (stackFrame: StackFrame) => boolean;
         sourceCache?: SourceCache;
         offline?: boolean;
-    }
-
-    export interface StackFrame {
-        constructor(object: StackFrame): StackFrame;
-
-        isConstructor?: boolean;
-        getIsConstructor(): boolean;
-        setIsConstructor(): void;
-
-        isEval?: boolean;
-        getIsEval(): boolean;
-        setIsEval(): void;
-
-        isNative?: boolean;
-        getIsNative(): boolean;
-        setIsNative(): void;
-
-        isTopLevel?: boolean;
-        getIsTopLevel(): boolean;
-        setIsTopLevel(): void;
-
-        columnNumber?: number;
-        getColumnNumber(): number;
-        setColumnNumber(): void;
-
-        lineNumber?: number;
-        getLineNumber(): number;
-        setLineNumber(): void;
-
-        fileName?: string;
-        getFileName(): string;
-        setFileName(): void;
-
-        functionName?: string;
-        getFunctionName(): string;
-        setFunctionName(): void;
-
-        source?: string;
-        getSource(): string;
-        setSource(): void;
-
-        args?: any[];
-        getArgs(): any[];
-        setArgs(): void;
-
-        evalOrigin?: StackFrame;
-        getEvalOrigin(): StackFrame;
-        setEvalOrigin(): void;
-
-        toString(): string;
     }
 
     /**
@@ -129,6 +81,6 @@ declare namespace StackTrace {
     export function report(stackframes: StackFrame[], url: string, errorMsg?: string, requestOptions?: object): Promise<any>;
 }
 
-declare module "stacktrace-js" {
-    export = StackTrace;
-}
+export = StackTrace;
+
+export as namespace StackTrace; // global for non-module UMD users


### PR DESCRIPTION
## Description
The slight incompatibility of the old definition was necessitating unsafe casts between `StackTrace.StackFrame` and `StackFrame`. See also stacktracejs/error-stack-parser#54.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc stacktrace.js` passes without errors
  - You don’t use JSCS anymore.
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
